### PR TITLE
Add `mutations_from_database` copy to `ActiveType.cast`

### DIFF
--- a/lib/active_type/util.rb
+++ b/lib/active_type/util.rb
@@ -22,6 +22,7 @@ module ActiveType
       klass.new do |casted|
         using_single_table_inheritance = using_single_table_inheritance?(klass, casted)
 
+        casted.instance_variable_set(:@mutations_from_database, record.instance_variable_get(:@mutations_from_database))
         # Rails 3.2, 4.2
         casted.instance_variable_set(:@attributes, record.instance_variable_get(:@attributes))
         # Rails 3.2


### PR DESCRIPTION
This PR adds `@mutations_from_database` instance variable copy to `ActiveType.cast_record` method. It's needed because [change method from ActiveSupport](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/dirty.rb#L225) uses this instance variable to carefully handle model changes. 

F.e. now I have a situation when [model setter is overridden by ActiveType gem](https://github.com/ErwinM/acts_as_tenant/blob/master/lib/acts_as_tenant/model_extensions.rb#L72-L85). Then after I cast existing record on form I have an issue with tracking this overridden attribute. It shown like changed (`{ "market_id" => [nil, 1] }`) but no changes happened on it at all. I think it happens because of this desynchronization between real database and model changes and form changes. 

So my point is to copy `@mutations_from_database` to be sure that all required trackers set or unset after model cast on form.